### PR TITLE
Add route for home to fix double routes showing up unsuccessful at li…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6026,6 +6026,11 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -6174,6 +6179,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6182,6 +6200,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -8502,6 +8528,16 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
@@ -10707,6 +10743,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
+    "react-router": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.1.2",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.2.0.tgz",
@@ -11114,6 +11196,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12417,6 +12504,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12822,6 +12919,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "jest": "^24.9.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0"
   },
   "jest": {

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,10 @@ import './App.css';
 import { getProjects, getAllPalettes } from './apiCalls/apiCalls';
 import SavedProjectsNav from './SavedProjectsNav/SavedProjectsNav';
 import SaveForm from './SaveForm/SaveForm';
-import Palette from './Palette/Palette'
+import Palette from './Palette/Palette';
+import Projects from './Projects/Projects';
+import { Route, NavLink } from 'react-router-dom';
+import Nav from './Nav/Nav';
 
 class App extends Component {
   constructor() {
@@ -28,18 +31,37 @@ async componentDidMount() {
 
 render() {
   const { projects } = this.state;
-  let projectList = projects.map((project, index) =>{
-    return <div key={index}>
-      <p>{project.name}</p>
-    </div>
-  })
+  // let projectList = projects.map((project, index) =>{
+  //   return <div key={index}>
+  //     <p>{project.name}</p>
+  //   </div>
+  // })
   return (
     <div>
-    <h1>Color Palette</h1>
-      { projectList }
-      <SavedProjectsNav projects={ this.state.projects }/>
-      <Palette />
-      <SaveForm projects={ this.state.projects } />
+      <Nav />
+      <main>
+        <Route exact path='/' render={() => (
+          <div>
+            <SavedProjectsNav projects={this.state.projects} />
+            <Palette />
+            <SaveForm projects={this.state.projects} />
+          </div>)}
+        />
+        <Route
+          path='/projects/:id'
+          render={({ match }) => {
+            const { id } = match.params;
+            const foundProject = projects.find(
+              project => project.id === parseInt(id)
+            )
+            return (
+              <div>
+                <Projects {...foundProject} palettes={this.state.palettes}/>
+              </div>
+            )
+          }}
+        />
+      </main>  
     </div>
   );
 }
@@ -48,3 +70,5 @@ render() {
 }
 
 export default App;
+
+// component = { NavLink } to = {`/projects/${foundProject.id}`}

--- a/src/Projects/Projects.css
+++ b/src/Projects/Projects.css
@@ -1,0 +1,5 @@
+td {
+  color: red;
+  width: 300px;
+  height:300px;
+}

--- a/src/Projects/Projects.js
+++ b/src/Projects/Projects.js
@@ -1,9 +1,36 @@
 import React from 'react';
+import './Projects.css';
 
-const Projects = () => {
+const Projects = (props) => {
+  let projectPalettes = props.palettes.filter(palette => {
+    if(palette.projectName === props.name) {
+      return palette
+    }
+  });
+  let paletteRow = projectPalettes.map((projPalette, index) => {
+   return (
+     <>
+     <tr>
+       <th>{projPalette.name}</th>
+     </tr>
+   <tr key={projPalette.id}>
+     <td key={index} style={{ backgroundColor: projPalette.colorOne }}>lock</td>
+     <td key={index} style={{ backgroundColor: projPalette.colorTwo }}>lock</td>
+     <td key={index} style={{ backgroundColor: projPalette.colorThree }}>lock</td>
+     <td key={index} style={{ backgroundColor: projPalette.colorFour }}>lock</td>
+     <td key={index} style={{ backgroundColor: projPalette.colorFive }}>lock</td>
+    </tr>
+    </>
+   )
+})
+  console.log("list", projectPalettes)
+  console.log("props in projects", props)
   return (
     <div>
-      Hey
+      <h1>{props.name}</h1>
+      <table>
+        {paletteRow}
+      </table>
     </div>
   )
 }

--- a/src/SavedProjectsNav/SavedProjectsNav.js
+++ b/src/SavedProjectsNav/SavedProjectsNav.js
@@ -1,7 +1,13 @@
 import React from 'react';
+// import { NavLink } from 'react-router-dom';
+
+// const goToProject = () => {
+
+// }
 
 const SavedProjectsNav = ({ projects }) => {
 let project = projects.map((project, index) => <button key={index}>{project.name}</button>);
+console.log(project.id)
   return (
     <div>
       { project }

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,15 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import { BrowserRouter } from 'react-router-dom';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const router = (
+  <BrowserRouter>
+    <App/>
+  </BrowserRouter>
+)
+
+ReactDOM.render(router, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
…nking on click so Add display for project palettes
@EmilyLalonde 
What is this change? Adds the display of palettes for a given project and displays the home route properly
What does it fix? Both routes are no longer showing on one route, but could not finish the onclick rerouting to projects.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? Unfortunately, I went down a rabbit whole and ended up not utilizing my workflow properly so this is one huge commit and push for one successful project component display and half of the routing functionality.
How has it been tested? Yes, in local host. It has not been pushed to heroku.