### PR TITLE
Name change

### DIFF
--- a/src/Projects/Projects.js
+++ b/src/Projects/Projects.js
@@ -1,8 +1,16 @@
 import React from 'react';
 import './Projects.css';
-import { updateProject } from '../apiCalls/apiCalls'
+import { updateProject, updatePalette } from '../apiCalls/apiCalls';
+
+const handlePaletteNameChange = (e, oldPalette) => {
+  const newPalette = {...oldPalette, name: e.target.innerText} 
+  updatePalette(newPalette)
+}
+
+// const handleProjectNameChange = (e, oldProjectName)
 
 const Projects = (props) => {
+  console.log('projects props', props)
   let projectPalettes = props.palettes.filter(palette => {
     if(palette.projectName === props.name) {
       return palette
@@ -12,7 +20,7 @@ const Projects = (props) => {
    return (
      <>
      <tr>
-       <th>{projPalette.name}</th>
+         <th contentEditable={true} onKeyUpCapture={(e) => handlePaletteNameChange(e, projPalette)}>{projPalette.name}</th>
      </tr>
    <tr key={projPalette.id}>
      <td key={index} style={{ backgroundColor: projPalette.colorOne }}>lock</td>
@@ -26,7 +34,7 @@ const Projects = (props) => {
 })
   return (
     <div>
-      <h2 contentEditable={true}>{props.name}</h2>
+      <h2 contentEditable={true}>{props.name} </h2>
       <table>
         {paletteRow}
       </table>

--- a/src/Projects/Projects.js
+++ b/src/Projects/Projects.js
@@ -7,8 +7,10 @@ const handlePaletteNameChange = (e, oldPalette) => {
   updatePalette(newPalette)
 }
 
-// const handleProjectNameChange = (e, oldProjectName)
-
+const handleProjectNameChange = (e, props) => {
+  const newProject = {id: props.id, name: e.target.innerText}
+  updateProject(newProject)
+}
 const Projects = (props) => {
   console.log('projects props', props)
   let projectPalettes = props.palettes.filter(palette => {
@@ -34,7 +36,7 @@ const Projects = (props) => {
 })
   return (
     <div>
-      <h2 contentEditable={true}>{props.name} </h2>
+      <h2 contentEditable={true} onKeyUpCapture={(e) => handleProjectNameChange(e, props)}>{props.name}</h2>
       <table>
         {paletteRow}
       </table>


### PR DESCRIPTION
What is this change? The content editable was already on the Project name so it gave me the idea to use content editable instead of an input and button which would have cluttered our UI, so thanks @EmilyLalonde for the idea. This adds editing for both project and palette names and updates them using the apicalls.
What does it fix? Users can alter names of projects and palettes
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? Feature
How has it been tested? In the browser