### PR TITLE
Fix deleting paletes when name change

### DIFF
--- a/src/Projects/Projects.js
+++ b/src/Projects/Projects.js
@@ -8,7 +8,10 @@ const handlePaletteNameChange = (e, oldPalette) => {
 }
 
 const handleProjectNameChange = (e, props) => {
-  const newProject = {id: props.id, name: e.target.innerText}
+  const newProjectName = e.target.innerText;
+  const keepPalettes = props.palettes.filter(palette => palette.projectId === props.id);
+  keepPalettes.forEach(keptPalette => updatePalette({...keptPalette, projectName: newProjectName}))
+  const newProject = {id: props.id, name: newProjectName}
   updateProject(newProject)
 }
 const Projects = (props) => {
@@ -18,6 +21,7 @@ const Projects = (props) => {
     }
   });
   let paletteRow = projectPalettes.map((projPalette, index) => {
+    console.log("props in projects", props)
    return (
      <>
      <tr>


### PR DESCRIPTION
 What is this change? The palettes of a project do not delete when a project name is updated
What does it fix? The palettes' objects are altered when the project name is altered so that the palettes remain with their project even when the name changes
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? Fix, some conflicts
How has it been tested? Yes, in the browser

@EmilyLalonde I am trying to do a pull request and it is giving me an error regarding moving those functions to app. Can you handle? 