### PR TITLE
Remove Date.now

### DIFF
--- a/src/RandomPalette/__snapshots__/RandomPalette.test.js.snap
+++ b/src/RandomPalette/__snapshots__/RandomPalette.test.js.snap
@@ -9,7 +9,7 @@ exports[`RandomPalette should match snapshot 1`] = `
   </h3>
   <div
     className="swatch"
-    key="1571291932872"
+    key="0"
     style={
       Object {
         "backgroundColor": undefined,

--- a/src/SavedProjectsNav/__snapshots__/SavedProjectsNav.test.js.snap
+++ b/src/SavedProjectsNav/__snapshots__/SavedProjectsNav.test.js.snap
@@ -8,7 +8,7 @@ exports[`SavedProjectsNav should match snapshot 1`] = `
     Your Saved Projects
   </h2>
   <NavLink
-    key="1571291933554"
+    key="0"
     to="/projects/1"
   >
     <button
@@ -18,7 +18,7 @@ exports[`SavedProjectsNav should match snapshot 1`] = `
     </button>
   </NavLink>
   <NavLink
-    key="1571291933556"
+    key="1"
     to="/projects/2"
   >
     <button


### PR DESCRIPTION
What is this change? Fix for the snapshot test
What does it fix? Date.now randomizes the snapshot outcome
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? The one above
How has it been tested? Yes